### PR TITLE
Fix bug in code to determine whether a child application should be attached to

### DIFF
--- a/src/ChildDebuggerService.cpp
+++ b/src/ChildDebuggerService.cpp
@@ -593,7 +593,7 @@ HRESULT STDMETHODCALLTYPE CChildDebuggerService::SendLower(
                             ProcessConfig{
                                 .applicationName = try_get_optional_string(configEntry, "applicationName"),
                                 .commandLine = try_get_optional_string(configEntry, "commandLine"),
-                                .attach = try_get_or(configEntry, "attachOthers", true)
+                                .attach = try_get_or(configEntry, "attach", true)
                             }
                         );
                     }


### PR DESCRIPTION
When the `lpApplicationName` argument to `CreateProcessXXX` was set to `nullptr`, the code could result in an empty `std::optional` being dereferenced. This has been fixed.

Additionally there was a typo when reading the process filters settings from the passed JSON string. This has been fixed too.